### PR TITLE
Add 8.8.8.8 as default nameserver in script

### DIFF
--- a/chp02/internetOverUSB
+++ b/chp02/internetOverUSB
@@ -2,4 +2,5 @@
 echo "Starting the Internet-over-USB script"
 /sbin/route add default gw 192.168.7.1
 /usr/sbin/ntpdate -b -s -u ie.pool.ntp.org
+echo "nameserver 8.8.8.8" >> /etc/resolv.conf
 echo "End of the settings script"


### PR DESCRIPTION
Added a default name server for DNS resolutions in order to have a working internet connection. Running the script with that option directly enabled internet on my BBB.

Regards.