### PR TITLE
Issue with ioctl

### DIFF
--- a/library/bus/SPIDevice.cpp
+++ b/library/bus/SPIDevice.cpp
@@ -86,6 +86,7 @@ int SPIDevice::open(){
  */
 int SPIDevice::transfer(unsigned char send[], unsigned char receive[], int length){
 	struct spi_ioc_transfer	transfer;
+	memset(&transfer,0,sizeof(transfer));
 	transfer.tx_buf = (unsigned long) send;
 	transfer.rx_buf = (unsigned long) receive;
 	transfer.len = length;


### PR DESCRIPTION
 "Error – Problem transmitting spi data..ioctl: Invalid argument

Due to changes in the underlying library the spi_ioc_transfer struct now needs to be initialised to NULL