### PR TITLE
<asm/uaccess.h> was deprecated in 4.12 and new code should use <linux…

### DIFF
--- a/extras/kernel/ebbchar/ebbchar.c
+++ b/extras/kernel/ebbchar/ebbchar.c
@@ -15,7 +15,7 @@
 #include <linux/device.h>         // Header to support the kernel Driver Model
 #include <linux/kernel.h>         // Contains types, macros, functions for the kernel
 #include <linux/fs.h>             // Header for the Linux file system support
-#include <asm/uaccess.h>          // Required for the copy to user function
+#include <linux/uaccess.h>          // Required for the copy to user function
 #define  DEVICE_NAME "ebbchar"    ///< The device will appear at /dev/ebbchar using this value
 #define  CLASS_NAME  "ebb"        ///< The device class -- this is a character device driver
 


### PR DESCRIPTION
…/uaccess.h>. see https://lkml.org/lkml/2017/9/19/332