### PR TITLE
Fix segfault on write() and writeRegister().

### DIFF
--- a/library/bus/SPIDevice.cpp
+++ b/library/bus/SPIDevice.cpp
@@ -138,9 +138,8 @@ unsigned char* SPIDevice::readRegisters(unsigned int number, unsigned int fromAd
  *  @return returns 0 if successful
  */
 int SPIDevice::write(unsigned char value){
-	unsigned char null_return = 0x00;
 	//printf("[%02x]", value);
-	this->transfer(&value, &null_return, 1);
+	this->transfer(&value, nullptr, 1);
 	return 0;
 }
 
@@ -151,8 +150,7 @@ int SPIDevice::write(unsigned char value){
  *  @return returns 0 if successful
  */
 int SPIDevice::write(unsigned char value[], int length){
-	unsigned char null_return = 0x00;
-	this->transfer(value, &null_return, length);
+	this->transfer(value, nullptr, length);
 	return 0;
 }
 


### PR DESCRIPTION
Passing address of local `char` as `spi_ioc_transfer.rx_buf` will segfault.
Though it's considered unused, `ioctl()` will still write to it, corrupting the call stack and result in a segfault. 
Use `nullptr` instead.