### PR TITLE
fix: Internal error: Accessing user space memory outside uaccess.h routines: 96000004 [#1] SMP

### DIFF
--- a/extras/kernel/ebbchar/ebbchar.c
+++ b/extras/kernel/ebbchar/ebbchar.c
@@ -142,7 +142,10 @@ static ssize_t dev_read(struct file *filep, char *buffer, size_t len, loff_t *of
  *  @param offset The offset if required
  */
 static ssize_t dev_write(struct file *filep, const char *buffer, size_t len, loff_t *offset){
-   sprintf(message, "%s(%zu letters)", buffer, len);   // appending received string with its length
+    if (copy_from_user(message, buffer, len)){
+        printk(KERN_ALERT "EBBChar: kernel failed  to copy message from user space\n");
+        return -EFAULT;
+    }
    size_of_message = strlen(message);                 // store the length of the stored message
    printk(KERN_INFO "EBBChar: Received %zu characters from the user\n", len);
    return len;


### PR DESCRIPTION
use copy_from_user() to fix:  Internal error: Accessing user space memory outside uaccess.h routines: 96000004 [#1] SMP

When I using an ARM server to test on ebbchar, I found segment fault at user space test program and had  Internal error as follow. It is because the const char* buffer point to user space address. And the later version of kernel seem to not allowed it.

My enviroment:

ARM64 server
Linux ubuntu 4.15.0-29-generic #31-Ubuntu SMP Tue Jul 17 15:41:03 UTC 2018 aarch64 aarch64 aarch64 GNU/Linux

The log:

EBBChar: Initializing the EBBChar LKM
EBBChar: registered correctly with major number 240
EBBChar: device class registered correctly
EBBChar: device class created correctly
EBBChar: Device has been opened 1 time(s)
Internal error: Accessing user space memory outside uaccess.h routines: 96000004 [#1] SMP
Modules linked in: ebbchar(OE) binfmt_misc nls_iso8859_1 joydev input_leds ipmi_ssif ipmi_si ipmi_devintf shpchp ipmi_msghandler sch_fq_codel ib_iser rdma_cm iw_cm ib_cm ib_core iscsi_tcp libiscsi_tcp libiscsi scsi_transport_iscsi ppdev lp parport nfsd auth_rpcgss nfs_acl lockd grace sunrpc ip_tables x_tables autofs4 btrfs zstd_compress raid10 raid456 async_raid6_recov async_memcpy async_pq async_xor async_tx xor raid6_pq libcrc32c raid1 raid0 multipath linear hid_generic usbhid hid ses enclosure marvell hibmc_drm aes_ce_blk ttm aes_ce_cipher crc32_ce drm_kms_helper crct10dif_ce ghash_ce syscopyarea sha2_ce sysfillrect sysimgblt sha256_arm64 fb_sys_fops sha1_ce drm hisi_sas_v2_hw hisi_sas_main ehci_platform libsas scsi_transport_sas hns_dsaf hns_enet_drv hns_mdio hnae aes_neon_bs aes_neon_blk
 crypto_simd cryptd aes_arm64 [last unloaded: ebbchar]
CPU: 17 PID: 10803 Comm: test Tainted: G        W  OE    4.15.0-29-generic #31-Ubuntu
Hardware name: BC11SPCD, BIOS 1.58 10/24/2018
pstate: 20400005 (nzCv daif +PAN -UAO)
pc : string+0x28/0xa0
lr : vsnprintf+0x5d4/0x730
sp : ffff000026ccbc90
x29: ffff000026ccbc90 x28: ffff000002ad40b2
x27: ffff000002ad40b2 x26: ffff000002ad5508
x25: 00000000ffffffd8 x24: 0000000000000020
x23: 000000007fffffff x22: ffff0000094f8000
x21: ffff000008c54b00 x20: ffff000082ad5507
x19: ffff000002ad5508 x18: 0000ffff8c2fda70
x17: 0000ffff8c26cb80 x16: ffff0000082e3a80
x15: 0000000000000000 x14: 0000000000000001
x13: 0000000000000000 x12: 0000000000000020
x11: ffff000026ccbdd0 x10: ffff000026ccbdd0
x9 : 00000000ffffffd0 x8 : fffffffffffffffe
x7 : ffff000002ad5508 x6 : 0000ffffe94b6b18
x5 : 0000000000000000 x4 : 0000000000000043
x3 : ffff0a00ffffff04 x2 : ffff000082ad5507
x1 : ffff000082ad5507 x0 : ffffffffffffffff
Process test (pid: 10803, stack limit = 0x00000000e31169af)
Call trace:
 string+0x28/0xa0
 vsnprintf+0x5d4/0x730
 sprintf+0x68/0x88
 dev_write+0x3c/0xb0 [ebbchar]
 __vfs_write+0x48/0x80
 vfs_write+0xac/0x1b0
 SyS_write+0x6c/0xd8
 el0_svc_naked+0x30/0x34
Code: f13ffcdf d1000408 540002c9 b4000320 (394000c5)
---[ end trace 2b89326b0d5f8b9f ]---
EBBChar: Device successfully closed